### PR TITLE
Fix Latte 2.5 compatibility (#164)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   - # dev
@@ -20,14 +19,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable" COVERAGE="--coverage ./coverage.xml --coverage-src ./src" TESTER_RUNTIME="phpdbg"
-    - php: 7.2
+    - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable" PHPSTAN=1
-    - php: 7.2
+    - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable" CODING_STANDARD=1
   exclude:
-    - php: 7.2
+    - php: 7.3
       env: COMPOSER_EXTRA_ARGS="--prefer-stable"
   allow_failures:
     - env:
@@ -40,10 +39,10 @@ install:
   - if [ "$COVERAGE" != "" ]; then travis_retry wget -O /tmp/coveralls.phar https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar; fi
 
 script:
-  - vendor/bin/tester $COVERAGE -s -p ${TESTER_RUNTIME:-php} -c ./tests/php.ini-unix ./tests/KdybyTests/
   - php /tmp/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
   - if [ "$PHPSTAN" = "1" ]; then php vendor/phpstan/phpstan-shim/phpstan.phar analyse --ansi --no-progress -l7 -c phpstan.neon src tests/KdybyTests; fi
   - if [ "$CODING_STANDARD" = "1" ]; then php vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 -sp src tests; fi
+  - vendor/bin/tester $COVERAGE -s -p ${TESTER_RUNTIME:-php} -c ./tests/php.ini-unix ./tests/KdybyTests/
 
 after_script:
   - if [ "$COVERAGE" != "" ]; then php /tmp/coveralls.phar --verbose --config tests/.coveralls.yml || true; fi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"issues": "https://github.com/kdyby/translation/issues"
 	},
 	"require": {
-		"php": "^5.6 || ^7.0",
+		"php": "^7.1",
 		"kdyby/strict-objects": "^1.0",
 		"latte/latte": "^2.4.6@dev",
 		"nette/caching": "^2.5@dev",
@@ -45,7 +45,7 @@
 		"nette/forms": "^2.4.6@dev",
 		"tracy/tracy": "^2.4.9@dev",
 		"kdyby/console": "^2.7.1@dev",
-		"kdyby/monolog": "^1.3.2@dev",
+		"kdyby/monolog": "^1.4.0@dev",
 		"symfony/yaml": "^3.4 || ^4.0",
 		"symfony/console": "^3.4 || ^4.0",
 		"nette/tester": "^2.0",

--- a/src/Extractors/LatteExtractor.php
+++ b/src/Extractors/LatteExtractor.php
@@ -46,7 +46,6 @@ class LatteExtractor implements \Symfony\Component\Translation\Extractor\Extract
 	{
 		$buffer = NULL;
 		$parser = new Parser();
-		$parser->shortNoEscape = TRUE;
 
 		foreach ($tokens = $parser->parse(file_get_contents($file)) as $token) {
 			if ($token->type !== $token::MACRO_TAG || !in_array($token->name, ['_', '/_'], TRUE)) {

--- a/src/Latte/TranslateMacros.php
+++ b/src/Latte/TranslateMacros.php
@@ -18,8 +18,6 @@ use Latte\PhpWriter;
 class TranslateMacros extends \Latte\Macros\MacroSet
 {
 
-	use \Kdyby\StrictObjects\Scream;
-
 	public static function install(Compiler $compiler)
 	{
 		$me = new static($compiler);


### PR DESCRIPTION
* Remove Kdyby\StrictObjects\Scream trait from Kdyby\Translation\Latte\TranslateMacros since it's ancestor uses Tracy\Strict

* Fix Kdyby\Monolog compatibility issue

* Drop support for PHP < 7.1, add PHP 7.3 to tests

* Move tests to the end of testing pipeline

* Remove shortNoEscape (deprecated in Latte 2.4.0 and removed in Latte 2.5.0)